### PR TITLE
Modernize for latest Crystal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+/bin/
+/crystalforce
 /doc/
+*.dwarf
 /libs/
 /.crystal/
 /.shards/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: crystal

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # crystalforce
 
-Crystalforce is a crystal shards for the Salesforce REST api.
+Crystalforce is a Crystal shard for the Salesforce REST API.
 
 ## Installation
-
 
 Add this to your application's `shard.yml`:
 
@@ -13,9 +12,27 @@ dependencies:
     github: masak1yu/crystalforce
 ```
 
+Then run:
+
+```sh
+shards install
+```
+
+## Development
+
+### Build
+
+```sh
+shards build
+```
+
+### Run tests
+
+```sh
+crystal spec
+```
 
 ## Usage
-
 
 ```crystal
 require "crystalforce"
@@ -26,35 +43,54 @@ require "crystalforce"
 #### Username/Password authentication
 
 ```crystal
-client = Crystalforce.new({
-  :username       => "foo",
-  :password       => "bar",
-  :security_token => "security_token",
-  :client_id      => "client_id",
-  :client_secret  => "client_secret"
-})
+client = Crystalforce.new(
+  username:       "foo",
+  password:       "bar",
+  security_token: "security_token",
+  client_id:      "client_id",
+  client_secret:  "client_secret",
+)
+```
+
+#### OAuth token refresh
+
+```crystal
+client = Crystalforce.new(
+  refresh_token: "refresh_token",
+  client_id:     "client_id",
+  client_secret: "client_secret",
+)
 ```
 
 #### Sandbox Orgs
 
 You can connect to sandbox orgs by specifying a host. The default host is
-'login.salesforce.com':
+`login.salesforce.com`:
 
 ```crystal
-client = Crystalforce.new({:host => 'test.salesforce.com'})
+client = Crystalforce.new(
+  host:          "test.salesforce.com",
+  username:       "foo",
+  password:       "bar",
+  security_token: "security_token",
+  client_id:      "client_id",
+  client_secret:  "client_secret",
+)
 ```
 
 ### API versions
 
-By default, the shard defaults to using version 34.0 of the Salesforce API.
-Some more recent API endpoints will not be available without moving to a more recent
-version - if you're trying to use a method that is unavailable with your API version,
-Restforce will raise an `APIVersionError`.
-
-You can change the `api_version` setting from the default either on a per-client basis:
+By default, the shard uses version 34.0 of the Salesforce API.
+You can change the `api_version` on a per-client basis:
 
 ```crystal
-client = Crystalforce.new({api_version: "36.0" # ...})
+client = Crystalforce.new(
+  api_version: "36.0",
+  username:    "foo",
+  password:    "bar",
+  client_id:   "client_id",
+  client_secret: "client_secret",
+)
 ```
 
 ### query
@@ -69,58 +105,40 @@ accounts = client.query("select Id, Something__c from Account where Id = 'someid
 accounts = client.query_all("select Id, Something__c from Account where isDeleted = true")
 ```
 
-query_all allows you to include results from your query that Salesforce hides in the default "query" method.  These include soft-deleted records and archived records (e.g. Task and Event records which are usually archived automatically after they are a year old).
-
-*Only available in [version 29.0](#api-versions) and later of the Salesforce API.*
+`query_all` allows you to include results from your query that Salesforce hides in the default `query` method. These include soft-deleted records and archived records (e.g. Task and Event records which are usually archived automatically after they are a year old).
 
 ### create
 
 ```crystal
-# Add a new account
-client.create("Account", {:Name => "Foobar Inc.""})
-# => '0016000000MRatd'
+client.create("Account", {:Name => "Foobar Inc."})
 ```
 
 ### update
 
 ```crystal
-# Update the Account with `Id` '0016000000MRatd'
 client.update("Account", "0016000000MRatd", {:Name => "Whizbang Corp"})
-# => true
 ```
 
 ### upsert
 
 ```crystal
-# Update the record with external `External__c` external ID set to '12'
-client.upsert("Account", "External__c", "External__c" => 12, "Name" => "Foobar")
-# => response.body["id"] or true
+client.upsert("Account", "External__c", {"External__c" => "12", "Name" => "Foobar"})
 ```
 
 ### destroy
 
 ```crystal
-# Delete the Account with `Id` '0016000000MRatd'
 client.destroy("Account", "0016000000MRatd")
-# => true
-```
-
-## notice
-
-If you are using TLS 1.0 or earlier version of the library, update the ssl library to the latest one and use the following option.
-
-```
-crystal run --link-flags "-L/path/to/openssl/lib/" <file>
 ```
 
 ## Contributing
 
-1. Fork it ( https://github.com/msky026/crystalforce/fork )
-2. Create your feature branch (git checkout -b my-new-feature)
-3. Commit your changes (git commit -am 'Add some feature')
-4. Push to the branch (git push origin my-new-feature)
+1. Fork it ( https://github.com/masak1yu/crystalforce/fork )
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
 
 ## Contributors
 
-- [msky](https://github.com/msky026) - creator, maintainer
+- [masak1yu](https://github.com/masak1yu) - creator, maintainer

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   crystalforce:
-    github: msky026/crystalforce
+    github: masak1yu/crystalforce
 ```
 
 

--- a/shard.yml
+++ b/shard.yml
@@ -4,4 +4,10 @@ version: 0.1.0
 authors:
   - masak1yu <antilogic@outlook.com>
 
+crystal: ">= 1.0.0"
+
+targets:
+  crystalforce:
+    main: src/crystalforce.cr
+
 license: MIT

--- a/shard.yml
+++ b/shard.yml
@@ -2,6 +2,6 @@ name: crystalforce
 version: 0.1.0
 
 authors:
-  - ucdmsky <antilogic@outlook.com>
+  - masak1yu <antilogic@outlook.com>
 
 license: MIT

--- a/spec/crystalforce_spec.cr
+++ b/spec/crystalforce_spec.cr
@@ -1,9 +1,4 @@
 require "./spec_helper"
 
 describe Crystalforce do
-  # TODO: Write tests
-
-  it "works" do
-    false.should eq(true)
-  end
 end

--- a/src/crystalforce.cr
+++ b/src/crystalforce.cr
@@ -1,7 +1,25 @@
 require "./crystalforce/*"
 
 module Crystalforce
-  def self.new(args : Hash(Symbol, String))
-    Crystalforce::Client.new(args)
+  def self.new(
+    username : String? = nil,
+    password : String? = nil,
+    security_token : String? = nil,
+    client_id : String? = nil,
+    client_secret : String? = nil,
+    refresh_token : String? = nil,
+    host : String = "login.salesforce.com",
+    api_version : String = "34.0"
+  )
+    Crystalforce::Client.new(
+      username: username,
+      password: password,
+      security_token: security_token,
+      client_id: client_id,
+      client_secret: client_secret,
+      refresh_token: refresh_token,
+      host: host,
+      api_version: api_version,
+    )
   end
 end

--- a/src/crystalforce/api.cr
+++ b/src/crystalforce/api.cr
@@ -4,7 +4,7 @@ require "uri"
 module Crystalforce
   module Api
     def query(soql)
-      query_str = URI.escape(soql)
+      query_str = URI.encode_www_form(soql)
       response = HTTP::Client.get "#{api_path}/query/?q=#{query_str}",
         HTTP::Headers{"Authorization" => "Bearer #{@access_token}"}
       if response && response.status_code != 200
@@ -15,7 +15,7 @@ module Crystalforce
     end
 
     def query_all(soql)
-      query_str = URI.escape(soql)
+      query_str = URI.encode_www_form(soql)
       response = HTTP::Client.get "#{api_path}/queryAll/?q=#{query_str}",
         HTTP::Headers{"Authorization" => "Bearer #{@access_token}"}
       if response && response.status_code != 200
@@ -25,10 +25,8 @@ module Crystalforce
       result["records"]
     end
 
-    # FIXME
     def search(sosl)
-      query_str = URI.escape(sosl)
-      p query_str
+      query_str = URI.encode_www_form(sosl)
       response = HTTP::Client.get "#{api_path}/search/?q=#{query_str}", HTTP::Headers{"Authorization" => "Bearer #{@access_token}"}
       if response && response.status_code != 200
         raise ServerError.new "Cannot connect salesforce"
@@ -48,7 +46,7 @@ module Crystalforce
       external_id = attrs.fetch(attrs.keys.find { |k| k.to_s.downcase == field.to_s.downcase }, nil)
       attrs_without_field = attrs.reject { |k, v| k.to_s.downcase == field.to_s.downcase }
       response =
-        HTTP::Client.patch "#{api_path}/sobjects/#{sobject}/#{field}/#{URI.escape(external_id.not_nil!.to_s)}",
+        HTTP::Client.patch "#{api_path}/sobjects/#{sobject}/#{field}/#{URI.encode_www_form(external_id.not_nil!.to_s)}",
         HTTP::Headers{"Authorization" => "Bearer #{@access_token}", "Content-Type" => "application/json"},
         attrs_without_field.to_json
       (response.body && response.body["id"]) ? response.body["id"] : true

--- a/src/crystalforce/authentication.cr
+++ b/src/crystalforce/authentication.cr
@@ -1,37 +1,23 @@
 require "http/client"
-require "openssl"
 
 module Crystalforce
   class Authentication
-    # Public: Force an authentication
-    def self.authenticate(options)
-      context = OpenSSL::SSL::Context::Client.new
-      if username_password?(options)
-        HTTP::Client.post "https://#{options[:host]}/services/oauth2/token",
-          form: "grant_type=password&client_id=#{options[:client_id]}&client_secret=#{options[:client_secret]}&username=#{options[:username]}&password=#{options[:password]}",
-          tls: context
-      elsif oauth_refresh?(options)
-        HTTP::Client.post "https://#{options[:host]}/services/oauth2/token",
-          form: "grant_type=refresh_token&refresh_token=#{options[:refresh_token]}&client_id=#{options[:client_id]}&client_secret=#{options[:client_secret]}",
-          tls: context
+    def self.authenticate(
+      username : String? = nil,
+      password : String? = nil,
+      security_token : String? = nil,
+      client_id : String? = nil,
+      client_secret : String? = nil,
+      refresh_token : String? = nil,
+      host : String = "login.salesforce.com"
+    )
+      if username && password && client_id && client_secret
+        HTTP::Client.post "https://#{host}/services/oauth2/token",
+          form: "grant_type=password&client_id=#{client_id}&client_secret=#{client_secret}&username=#{username}&password=#{password}"
+      elsif refresh_token && client_id && client_secret
+        HTTP::Client.post "https://#{host}/services/oauth2/token",
+          form: "grant_type=refresh_token&refresh_token=#{refresh_token}&client_id=#{client_id}&client_secret=#{client_secret}"
       end
-    end
-
-    # Internal: Returns true if username/password (autonomous) flow should be used for
-    # authentication.
-    def self.username_password?(options)
-      options[:username]? &&
-        options[:password]? &&
-        options[:client_id]? &&
-        options[:client_secret]?
-    end
-
-    # Internal: Returns true if oauth token refresh flow should be used for
-    # authentication.
-    def self.oauth_refresh?(options)
-      options[:refresh_token]? &&
-        options[:client_id]? &&
-        options[:client_secret]?
     end
   end
 end

--- a/src/crystalforce/client.cr
+++ b/src/crystalforce/client.cr
@@ -2,15 +2,29 @@ module Crystalforce
   class Client
     include Crystalforce::Api
 
-    def initialize(args : Hash(Symbol, String))
-      @api_version = ""
+    def initialize(
+      username : String? = nil,
+      password : String? = nil,
+      security_token : String? = nil,
+      client_id : String? = nil,
+      client_secret : String? = nil,
+      refresh_token : String? = nil,
+      host : String = "login.salesforce.com",
+      api_version : String = "34.0"
+    )
+      @api_version = api_version
       @access_token = ""
       @instance_url = ""
-      args[:api_version] = args[:api_version]? ? args[:api_version] : "34.0"
-      args[:host] = "login.salesforce.com" unless args[:host]?
-      @api_version = args[:api_version]
 
-      response = Crystalforce::Authentication.authenticate(args)
+      response = Crystalforce::Authentication.authenticate(
+        username: username,
+        password: password,
+        security_token: security_token,
+        client_id: client_id,
+        client_secret: client_secret,
+        refresh_token: refresh_token,
+        host: host,
+      )
       if response && response.status_code != 200
         raise AuthenticationError.new "No authentication middleware present"
       end


### PR DESCRIPTION
## Summary
- `Hash(Symbol, String)` パラメータを名前付き引数に変更
- 非推奨の `URI.escape` を `URI.encode_www_form` に置換
- 不要になった明示的な `OpenSSL::SSL::Context` を削除（Crystal が HTTPS の TLS を自動処理）
- 不要なコメント・デバッグ出力・`.travis.yml` を削除
- `shard.yml` / `README.md` の author 名・GitHub URL を修正

## Test plan
- [ ] `crystal build src/crystalforce.cr` でコンパイルが通ることを確認
- [ ] Salesforce sandbox 環境で認証・クエリが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)