### PR TITLE
v0.1.1: Add JWT/Client Credentials auth, auto-retry, callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # crystalforce
 
 Crystalforce is a Crystal shard for the Salesforce REST API.
+A Crystal port of [Restforce](https://github.com/restforce/restforce).
 
 ## Installation
 
@@ -62,6 +63,29 @@ client = Crystalforce.new(
 )
 ```
 
+#### JWT Bearer authentication
+
+```crystal
+jwt_key = File.read("path/to/private_key.pem")
+client = Crystalforce.new(
+  username:  "foo",
+  client_id: "client_id",
+  jwt_key:   jwt_key,
+)
+```
+
+#### Client Credentials authentication
+
+Requires the `host` to be set to your My Domain URL:
+
+```crystal
+client = Crystalforce.new(
+  client_id:     "client_id",
+  client_secret: "client_secret",
+  host:          "yourdomain.my.salesforce.com",
+)
+```
+
 #### Sandbox Orgs
 
 You can connect to sandbox orgs by specifying a host. The default host is
@@ -69,7 +93,7 @@ You can connect to sandbox orgs by specifying a host. The default host is
 
 ```crystal
 client = Crystalforce.new(
-  host:          "test.salesforce.com",
+  host:           "test.salesforce.com",
   username:       "foo",
   password:       "bar",
   security_token: "security_token",
@@ -78,18 +102,48 @@ client = Crystalforce.new(
 )
 ```
 
-### API versions
+### Options
+
+#### API versions
 
 By default, the shard uses version 34.0 of the Salesforce API.
 You can change the `api_version` on a per-client basis:
 
 ```crystal
 client = Crystalforce.new(
-  api_version: "36.0",
-  username:    "foo",
-  password:    "bar",
-  client_id:   "client_id",
+  api_version:  "36.0",
+  username:     "foo",
+  password:     "bar",
+  client_id:    "client_id",
   client_secret: "client_secret",
+)
+```
+
+#### Authentication retries
+
+When an API call returns a 401 Unauthorized, the client automatically
+re-authenticates and retries the request. The default retry count is 3:
+
+```crystal
+client = Crystalforce.new(
+  authentication_retries: 5,
+  # ... auth params
+)
+```
+
+#### Authentication callback
+
+You can provide a callback that is invoked after each successful authentication
+(including re-authentications on 401):
+
+```crystal
+callback = Proc(Crystalforce::Client, Nil).new do |client|
+  puts "Authenticated! Token: #{client.access_token}"
+end
+
+client = Crystalforce.new(
+  authentication_callback: callback,
+  # ... auth params
 )
 ```
 
@@ -106,6 +160,12 @@ accounts = client.query_all("select Id, Something__c from Account where isDelete
 ```
 
 `query_all` allows you to include results from your query that Salesforce hides in the default `query` method. These include soft-deleted records and archived records (e.g. Task and Event records which are usually archived automatically after they are a year old).
+
+### search
+
+```crystal
+results = client.search("FIND {Foobar Inc.}")
+```
 
 ### create
 

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: crystalforce
-version: 0.1.0
+version: 0.1.1
 
 authors:
   - masak1yu <antilogic@outlook.com>

--- a/src/crystalforce.cr
+++ b/src/crystalforce.cr
@@ -8,8 +8,11 @@ module Crystalforce
     client_id : String? = nil,
     client_secret : String? = nil,
     refresh_token : String? = nil,
+    jwt_key : String? = nil,
     host : String = "login.salesforce.com",
-    api_version : String = "34.0"
+    api_version : String = "34.0",
+    authentication_retries : Int32 = 3,
+    authentication_callback : Proc(Client, Nil)? = nil
   )
     Crystalforce::Client.new(
       username: username,
@@ -18,8 +21,11 @@ module Crystalforce
       client_id: client_id,
       client_secret: client_secret,
       refresh_token: refresh_token,
+      jwt_key: jwt_key,
       host: host,
       api_version: api_version,
+      authentication_retries: authentication_retries,
+      authentication_callback: authentication_callback,
     )
   end
 end

--- a/src/crystalforce/api.cr
+++ b/src/crystalforce/api.cr
@@ -5,9 +5,11 @@ module Crystalforce
   module Api
     def query(soql)
       query_str = URI.encode_www_form(soql)
-      response = HTTP::Client.get "#{api_path}/query/?q=#{query_str}",
-        HTTP::Headers{"Authorization" => "Bearer #{@access_token}"}
-      if response && response.status_code != 200
+      response = with_retry do
+        HTTP::Client.get "#{api_path}/query/?q=#{query_str}",
+          headers: auth_headers
+      end
+      if response.status_code != 200
         raise ServerError.new "Cannot connect salesforce"
       end
       result = JSON.parse(response.body)
@@ -16,9 +18,11 @@ module Crystalforce
 
     def query_all(soql)
       query_str = URI.encode_www_form(soql)
-      response = HTTP::Client.get "#{api_path}/queryAll/?q=#{query_str}",
-        HTTP::Headers{"Authorization" => "Bearer #{@access_token}"}
-      if response && response.status_code != 200
+      response = with_retry do
+        HTTP::Client.get "#{api_path}/queryAll/?q=#{query_str}",
+          headers: auth_headers
+      end
+      if response.status_code != 200
         raise ServerError.new "Cannot connect salesforce"
       end
       result = JSON.parse(response.body)
@@ -27,37 +31,60 @@ module Crystalforce
 
     def search(sosl)
       query_str = URI.encode_www_form(sosl)
-      response = HTTP::Client.get "#{api_path}/search/?q=#{query_str}", HTTP::Headers{"Authorization" => "Bearer #{@access_token}"}
-      if response && response.status_code != 200
+      response = with_retry do
+        HTTP::Client.get "#{api_path}/search/?q=#{query_str}",
+          headers: auth_headers
+      end
+      if response.status_code != 200
         raise ServerError.new "Cannot connect salesforce"
       end
-      result = JSON.parse(response.body)
+      JSON.parse(response.body)
     end
 
     def create(sobject, attrs)
-      HTTP::Client.post "#{api_path}/sobjects/#{sobject}/", HTTP::Headers{"Authorization" => "Bearer #{@access_token}", "Content-Type" => "application/json"}, attrs.to_json
+      with_retry do
+        HTTP::Client.post "#{api_path}/sobjects/#{sobject}/",
+          headers: auth_headers_with_json,
+          body: attrs.to_json
+      end
     end
 
     def update(sobject, id, attrs)
-      HTTP::Client.patch "#{api_path}/sobjects/#{sobject}/#{id}", HTTP::Headers{"Authorization" => "Bearer #{@access_token}", "Content-Type" => "application/json"}, attrs.to_json
+      with_retry do
+        HTTP::Client.patch "#{api_path}/sobjects/#{sobject}/#{id}",
+          headers: auth_headers_with_json,
+          body: attrs.to_json
+      end
     end
 
     def upsert(sobject, field, attrs)
       external_id = attrs.fetch(attrs.keys.find { |k| k.to_s.downcase == field.to_s.downcase }, nil)
       attrs_without_field = attrs.reject { |k, v| k.to_s.downcase == field.to_s.downcase }
-      response =
+      response = with_retry do
         HTTP::Client.patch "#{api_path}/sobjects/#{sobject}/#{field}/#{URI.encode_www_form(external_id.not_nil!.to_s)}",
-        HTTP::Headers{"Authorization" => "Bearer #{@access_token}", "Content-Type" => "application/json"},
-        attrs_without_field.to_json
+          headers: auth_headers_with_json,
+          body: attrs_without_field.to_json
+      end
       (response.body && response.body["id"]) ? response.body["id"] : true
     end
 
     def destroy(sobject, id)
-      HTTP::Client.delete "#{api_path}/sobjects/#{sobject}/#{id}", HTTP::Headers{"Authorization" => "Bearer #{@access_token}"}
+      with_retry do
+        HTTP::Client.delete "#{api_path}/sobjects/#{sobject}/#{id}",
+          headers: auth_headers
+      end
     end
 
     private def api_path
       "#{@instance_url}/services/data/v#{@api_version}"
+    end
+
+    private def auth_headers
+      HTTP::Headers{"Authorization" => "Bearer #{@access_token}"}
+    end
+
+    private def auth_headers_with_json
+      HTTP::Headers{"Authorization" => "Bearer #{@access_token}", "Content-Type" => "application/json"}
     end
   end
 end

--- a/src/crystalforce/authentication.cr
+++ b/src/crystalforce/authentication.cr
@@ -1,4 +1,19 @@
 require "http/client"
+require "json"
+require "base64"
+require "uri"
+require "openssl"
+
+lib LibCrypto
+  type EVP_PKEY = Void*
+  type EVP_PKEY_CTX = Void*
+
+  fun BIO_new_mem_buf(buf : UInt8*, len : Int32) : Bio*
+  fun PEM_read_bio_PrivateKey(bp : Bio*, x : EVP_PKEY*, cb : Void*, u : Void*) : EVP_PKEY
+  fun EVP_DigestSignInit(ctx : EVP_MD_CTX, pctx : EVP_PKEY_CTX*, type : EVP_MD, e : Void*, pkey : EVP_PKEY) : Int32
+  fun EVP_DigestSignUpdate(ctx : EVP_MD_CTX, d : UInt8*, cnt : LibC::SizeT) : Int32
+  fun EVP_DigestSignFinal(ctx : EVP_MD_CTX, sig : UInt8*, siglen : LibC::SizeT*) : Int32
+end
 
 module Crystalforce
   class Authentication
@@ -9,15 +24,121 @@ module Crystalforce
       client_id : String? = nil,
       client_secret : String? = nil,
       refresh_token : String? = nil,
+      jwt_key : String? = nil,
       host : String = "login.salesforce.com"
     )
-      if username && password && client_id && client_secret
-        HTTP::Client.post "https://#{host}/services/oauth2/token",
-          form: "grant_type=password&client_id=#{client_id}&client_secret=#{client_secret}&username=#{username}&password=#{password}"
+      if jwt_key && client_id && username
+        authenticate_jwt(jwt_key, client_id, username, host)
+      elsif client_id && client_secret && !username && !refresh_token && !jwt_key
+        authenticate_client_credentials(client_id, client_secret, host)
+      elsif username && password && client_id && client_secret
+        authenticate_password(username, password, security_token, client_id, client_secret, host)
       elsif refresh_token && client_id && client_secret
-        HTTP::Client.post "https://#{host}/services/oauth2/token",
-          form: "grant_type=refresh_token&refresh_token=#{refresh_token}&client_id=#{client_id}&client_secret=#{client_secret}"
+        authenticate_refresh_token(refresh_token, client_id, client_secret, host)
       end
+    end
+
+    private def self.authenticate_password(username, password, security_token, client_id, client_secret, host)
+      form = URI::Params.encode({
+        "grant_type"    => "password",
+        "client_id"     => client_id,
+        "client_secret" => client_secret,
+        "username"      => username,
+        "password"      => "#{password}#{security_token}",
+      })
+      HTTP::Client.post("https://#{host}/services/oauth2/token", form: form)
+    end
+
+    private def self.authenticate_refresh_token(refresh_token, client_id, client_secret, host)
+      form = URI::Params.encode({
+        "grant_type"    => "refresh_token",
+        "refresh_token" => refresh_token,
+        "client_id"     => client_id,
+        "client_secret" => client_secret,
+      })
+      HTTP::Client.post("https://#{host}/services/oauth2/token", form: form)
+    end
+
+    private def self.authenticate_jwt(jwt_key, client_id, username, host)
+      assertion = build_jwt(jwt_key, client_id, username, host)
+      form = URI::Params.encode({
+        "grant_type" => "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        "assertion"  => assertion,
+      })
+      HTTP::Client.post("https://#{host}/services/oauth2/token", form: form)
+    end
+
+    private def self.authenticate_client_credentials(client_id, client_secret, host)
+      form = URI::Params.encode({
+        "grant_type"    => "client_credentials",
+        "client_id"     => client_id,
+        "client_secret" => client_secret,
+      })
+      HTTP::Client.post("https://#{host}/services/oauth2/token", form: form)
+    end
+
+    private def self.build_jwt(private_key_pem : String, client_id : String, username : String, host : String) : String
+      header = {"alg" => "RS256", "typ" => "JWT"}
+      payload = {
+        "iss" => client_id,
+        "sub" => username,
+        "aud" => "https://#{host}",
+        "exp" => Time.utc.to_unix + 300,
+      }
+
+      header_b64 = base64url_encode(header.to_json)
+      payload_b64 = base64url_encode(payload.to_json)
+      signing_input = "#{header_b64}.#{payload_b64}"
+
+      signature = rsa_sha256_sign(private_key_pem, signing_input)
+      signature_b64 = base64url_encode_raw(signature)
+
+      "#{signing_input}.#{signature_b64}"
+    end
+
+    private def self.rsa_sha256_sign(pem : String, data : String) : Bytes
+      bio = LibCrypto.BIO_new_mem_buf(pem.to_unsafe, pem.bytesize)
+      raise AuthenticationError.new("Failed to create BIO") unless bio
+
+      pkey = LibCrypto.PEM_read_bio_PrivateKey(bio, nil, nil, nil)
+      LibCrypto.BIO_free(bio)
+      raise AuthenticationError.new("Failed to read private key") unless pkey
+
+      ctx = LibCrypto.evp_md_ctx_new
+      raise AuthenticationError.new("Failed to create EVP_MD_CTX") unless ctx
+
+      begin
+        pctx = Pointer(Void).null.as(LibCrypto::EVP_PKEY_CTX)
+        if LibCrypto.EVP_DigestSignInit(ctx, pointerof(pctx), LibCrypto.evp_sha256, nil, pkey) != 1
+          raise AuthenticationError.new("Failed to initialize signing")
+        end
+
+        if LibCrypto.EVP_DigestSignUpdate(ctx, data.to_unsafe, data.bytesize) != 1
+          raise AuthenticationError.new("Failed to update signing")
+        end
+
+        sig_len = LibC::SizeT.new(0)
+        if LibCrypto.EVP_DigestSignFinal(ctx, nil, pointerof(sig_len)) != 1
+          raise AuthenticationError.new("Failed to get signature length")
+        end
+
+        signature = Bytes.new(sig_len)
+        if LibCrypto.EVP_DigestSignFinal(ctx, signature, pointerof(sig_len)) != 1
+          raise AuthenticationError.new("Failed to finalize signature")
+        end
+
+        signature[0, sig_len]
+      ensure
+        LibCrypto.evp_md_ctx_free(ctx)
+      end
+    end
+
+    private def self.base64url_encode(data : String) : String
+      Base64.urlsafe_encode(data).gsub("=", "")
+    end
+
+    private def self.base64url_encode_raw(data : Bytes) : String
+      Base64.urlsafe_encode(data).gsub("=", "")
     end
   end
 end

--- a/src/crystalforce/client.cr
+++ b/src/crystalforce/client.cr
@@ -9,30 +9,71 @@ module Crystalforce
       client_id : String? = nil,
       client_secret : String? = nil,
       refresh_token : String? = nil,
+      jwt_key : String? = nil,
       host : String = "login.salesforce.com",
-      api_version : String = "34.0"
+      api_version : String = "34.0",
+      authentication_retries : Int32 = 3,
+      authentication_callback : Proc(Client, Nil)? = nil
     )
       @api_version = api_version
       @access_token = ""
       @instance_url = ""
+      @authentication_retries = authentication_retries
+      @authentication_callback = authentication_callback
 
+      # Store auth params for re-authentication
+      @username = username
+      @password = password
+      @security_token = security_token
+      @client_id = client_id
+      @client_secret = client_secret
+      @refresh_token = refresh_token
+      @jwt_key = jwt_key
+      @host = host
+
+      perform_authentication
+    end
+
+    getter access_token : String
+    getter instance_url : String
+
+    protected def perform_authentication
       response = Crystalforce::Authentication.authenticate(
-        username: username,
-        password: password,
-        security_token: security_token,
-        client_id: client_id,
-        client_secret: client_secret,
-        refresh_token: refresh_token,
-        host: host,
+        username: @username,
+        password: @password,
+        security_token: @security_token,
+        client_id: @client_id,
+        client_secret: @client_secret,
+        refresh_token: @refresh_token,
+        jwt_key: @jwt_key,
+        host: @host,
       )
       if response && response.status_code != 200
-        raise AuthenticationError.new "No authentication middleware present"
+        body = JSON.parse(response.body) rescue nil
+        error_desc = body.try(&.["error_description"]?.try(&.as_s)) || "Authentication failed"
+        raise AuthenticationError.new(error_desc)
       end
 
       if response
         res = JSON.parse(response.body)
         @access_token = res["access_token"].to_s
         @instance_url = res["instance_url"].to_s
+        @authentication_callback.try(&.call(self))
+      else
+        raise AuthenticationError.new("No valid authentication parameters provided")
+      end
+    end
+
+    protected def with_retry(&)
+      retries = 0
+      loop do
+        response = yield
+        if response.is_a?(HTTP::Client::Response) && response.status_code == 401 && retries < @authentication_retries
+          retries += 1
+          perform_authentication
+        else
+          return response
+        end
       end
     end
   end

--- a/src/crystalforce/version.cr
+++ b/src/crystalforce/version.cr
@@ -1,3 +1,3 @@
 module Crystalforce
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
## Summary
- Add JWT Bearer authentication (RS256 signing via direct LibCrypto bindings, no external shards)
- Add Client Credentials authentication
- Fix password auth to properly concatenate security_token
- Add automatic re-authentication on 401 with configurable retry count (`authentication_retries`, default: 3)
- Add `authentication_callback` for post-auth hooks
- Wrap all API methods with retry logic
- Improve error messages using Salesforce API response
- Properly URL-encode form parameters
- Update README with new auth methods and options

## Test plan
- [x] JWT Bearer auth tested against Salesforce Developer Edition
- [x] Client Credentials auth tested against Salesforce Developer Edition
- [x] authentication_callback confirmed to fire on auth success
- [x] Query API confirmed working with both auth methods
- [ ] Manual verification of 401 auto-retry (token expiry scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)